### PR TITLE
Fix theme injection and add print preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "19.1.0",
         "react-resizable-panels": "^3.0.3",
         "reveal.js": "^5.2.1",
+        "sonner": "^1.7.4",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -9995,6 +9996,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "19.1.0",
     "react-resizable-panels": "^3.0.3",
     "reveal.js": "^5.2.1",
+    "sonner": "^1.7.4",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/utils";
+import { Toaster } from "@/components/ui/sonner";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -24,6 +25,7 @@ export default function RootLayout({
         )}
       >
         {children}
+        <Toaster richColors />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { generateNewKeyString, encrypt, importKey } from "@/lib/crypto";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
+import { toast } from "sonner";
 
 export default function Home() {
   const router = useRouter();
@@ -22,7 +23,9 @@ export default function Home() {
 
         router.push(`/p/${publicId}/e/${editKey}/h#${decryptionKey}`);
       } catch (error) {
-        alert(`Error creating presentation: ${error instanceof Error ? error.message : "Unknown error"}`);
+        toast.error(
+          `Error creating presentation: ${error instanceof Error ? error.message : "Unknown error"}`
+        );
       }
     });
   };

--- a/src/components/editor/PresentationEditor.test.tsx
+++ b/src/components/editor/PresentationEditor.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { PresentationEditor } from "./PresentationEditor";
 import * as crypto from "@/lib/crypto";
 import * as actions from "@/app/actions";
+import { toast } from "sonner";
 
 // Mock dependencies
 vi.mock("@/lib/crypto");
@@ -21,7 +22,8 @@ describe("PresentationEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.location.hash = "#test-key";
-    window.alert = vi.fn(); // Mock window.alert
+    vi.spyOn(toast, "error").mockImplementation(() => "");
+    vi.spyOn(toast, "success").mockImplementation(() => "");
   });
 
   it("should show an error alert if encryption fails on save", async () => {
@@ -41,7 +43,7 @@ describe("PresentationEditor", () => {
 
     // Wait for the alert to be called
     await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith(
+      expect(toast.error).toHaveBeenCalledWith(
         `Error saving: ${errorMessage}`
       );
     });
@@ -63,7 +65,7 @@ describe("PresentationEditor", () => {
     fireEvent.click(screen.getByText("Save Changes"));
 
     await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith(
+      expect(toast.error).toHaveBeenCalledWith(
         "Cannot save. Decryption key or edit key is missing."
       );
     });

--- a/src/components/editor/PrintPreview.tsx
+++ b/src/components/editor/PrintPreview.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import type { getPresentation } from "@/app/actions";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { PrintView2 } from "./PrintView2";
+
+export type Presentation = NonNullable<Awaited<ReturnType<typeof getPresentation>>> & {
+  slides: { id?: number; content: string; order: number; presentationId: number }[];
+};
+
+export function PrintPreview({ presentation }: { presentation: Presentation }) {
+  const [config, setConfig] = useState({
+    progress: true,
+    controls: true,
+    center: true,
+    pdfSeparateFragments: true,
+    pdfMaxPagesPerSlide: 1,
+    pdfPageHeightOffset: -1,
+  });
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-xl font-bold">Print Preview</h3>
+      <div className="grid grid-cols-2 gap-4">
+        <label className="flex items-center space-x-2">
+          <Switch
+            checked={config.progress}
+            onCheckedChange={(v) => setConfig({ ...config, progress: v })}
+          />
+          <span>Progress</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <Switch
+            checked={config.controls}
+            onCheckedChange={(v) => setConfig({ ...config, controls: v })}
+          />
+          <span>Controls</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <Switch
+            checked={config.center}
+            onCheckedChange={(v) => setConfig({ ...config, center: v })}
+          />
+          <span>Center</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <Switch
+            checked={config.pdfSeparateFragments}
+            onCheckedChange={(v) =>
+              setConfig({ ...config, pdfSeparateFragments: v })
+            }
+          />
+          <span>Separate Fragments</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <span>Max Pages Per Slide</span>
+          <Input
+            type="number"
+            value={config.pdfMaxPagesPerSlide}
+            onChange={(e) =>
+              setConfig({ ...config, pdfMaxPagesPerSlide: Number(e.target.value) })
+            }
+            className="w-20"
+          />
+        </label>
+        <label className="flex items-center space-x-2">
+          <span>Page Height Offset</span>
+          <Input
+            type="number"
+            value={config.pdfPageHeightOffset}
+            onChange={(e) =>
+              setConfig({ ...config, pdfPageHeightOffset: Number(e.target.value) })
+            }
+            className="w-20"
+          />
+        </label>
+      </div>
+      <div className="border rounded-md p-2">
+        <PrintView2 presentation={presentation} config={config} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/PrintView2.tsx
+++ b/src/components/editor/PrintView2.tsx
@@ -15,6 +15,7 @@ type Presentation = NonNullable<Awaited<ReturnType<typeof getPresentation>>>;
 
 interface PrintView2Props {
   presentation: Presentation;
+  config?: Record<string, unknown>;
 }
 
 // By declaring the deck instance outside the component, we ensure it's a singleton
@@ -22,7 +23,7 @@ interface PrintView2Props {
 // This is the correct pattern you provided.
 let deck: Reveal.Api | null = null;
 
-export function PrintView2({ presentation }: PrintView2Props) {
+export function PrintView2({ presentation, config = {} }: PrintView2Props) {
   const themeLinkRef = useRef<HTMLLinkElement | null>(null);
   const revealRef = useRef<HTMLDivElement | null>(null);
 
@@ -59,8 +60,6 @@ export function PrintView2({ presentation }: PrintView2Props) {
         console.log("Initializing Reveal at", window.location.href);
         deck = new Reveal(revealRef.current!, {
           hash: false,
-          // Use Reveal's default slide dimensions to avoid overly small text
-          // when the deck scales slides to fit the viewport.
           progress: true,
           history: false,
           center: true,
@@ -70,6 +69,7 @@ export function PrintView2({ presentation }: PrintView2Props) {
           pdfMaxPagesPerSlide: 1,
           pdfPageHeightOffset: -1,
           transition: "slide",
+          ...config,
           plugins: [Markdown, Highlight, Notes],
         });
         await deck.initialize();
@@ -100,7 +100,7 @@ export function PrintView2({ presentation }: PrintView2Props) {
         deck = null;
       }
     };
-  }, []);
+  }, [config]);
 
   const allSlides = presentation.slides.map((s) => s.content).join("\n---\n");
   console.log("All slide markdown", allSlides);

--- a/src/components/editor/RevealPreview.tsx
+++ b/src/components/editor/RevealPreview.tsx
@@ -11,29 +11,11 @@ interface RevealPreviewProps {
   theme: string;
 }
 
-export function RevealPreview({ markdown, theme }: RevealPreviewProps) {
+// 'theme' prop is kept for API consistency; the PresentationEditor manages the theme link globally
+export function RevealPreview({ markdown, theme: _theme }: RevealPreviewProps) {
   const deckRef = useRef<Reveal.Api | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const themeLinkRef = useRef<HTMLLinkElement | null>(null);
-
-  // Effect for theme switching
-  useEffect(() => {
-    if (!themeLinkRef.current) {
-      const link = document.createElement("link");
-      link.rel = "stylesheet";
-      document.head.appendChild(link);
-      themeLinkRef.current = link;
-    }
-    themeLinkRef.current.href = `/api/themes/${theme}`;
-
-    return () => {
-      // On component unmount, remove the theme link
-      if (themeLinkRef.current) {
-        themeLinkRef.current.remove();
-        themeLinkRef.current = null;
-      }
-    };
-  }, [theme]);
+  // Theme link is managed globally by PresentationEditor
 
   // Effect for one-time initialization
   useEffect(() => {

--- a/src/components/editor/ShareDialog.tsx
+++ b/src/components/editor/ShareDialog.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { toast } from "sonner";
 
 interface ShareDialogProps {
   isOpen: boolean;
@@ -30,7 +31,9 @@ export function ShareDialog({ isOpen, onClose, publicId, editKey }: ShareDialogP
   const editUrl = editKey ? `${baseUrl}/p/${publicId}/e/${editKey}/h#${decryptionKey}` : "";
 
   const copyToClipboard = (text: string) => {
-    void navigator.clipboard.writeText(text).then(() => alert("Link copied to clipboard!"));
+    void navigator.clipboard
+      .writeText(text)
+      .then(() => toast.success("Link copied to clipboard!"));
   };
 
   return (

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Toaster as Sonner } from "sonner";
+
+export function Toaster(props: React.ComponentProps<typeof Sonner>) {
+  return <Sonner {...props} />;
+}

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,9 +1,13 @@
 export const themes = [
-  "black.css",
-  "white.css",
-  "league.css",
   "beige.css",
-  "sky.css",
+  "black.css",
+  "blood.css",
+  "league.css",
+  "moon.css",
   "night.css",
   "serif.css",
+  "simple.css",
+  "sky.css",
+  "solarized.css",
+  "white.css",
 ];


### PR DESCRIPTION
## Summary
- handle theme styles in `PresentationEditor`
- add toast notifications via sonner
- expose `PrintPreview` settings panel and `PrintView2` config
- inject `Toaster` in root layout
- update unit tests

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687cd745f8048333b6e77bd97675d062