### PR TITLE
Refactor saving UX

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,16 +2,21 @@
 
 import { createPresentation } from "@/app/actions";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { generateNewKeyString, encrypt, importKey } from "@/lib/crypto";
+import { cn } from "@/lib/utils";
 import { useRouter } from "next/navigation";
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 
 export default function Home() {
   const router = useRouter();
   const [isCreating, startCreateTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+  const [statusType, setStatusType] = useState<"error" | null>(null);
 
   const handleCreate = () => {
     startCreateTransition(async () => {
+      setStatus(null);
       try {
         const decryptionKey = await generateNewKeyString();
         const key = await importKey(decryptionKey);
@@ -22,16 +27,34 @@ export default function Home() {
 
         router.push(`/p/${publicId}/e/${editKey}/h#${decryptionKey}`);
       } catch (error) {
-        alert(`Error creating presentation: ${error instanceof Error ? error.message : "Unknown error"}`);
+        setStatus(
+          `Error creating presentation: ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`
+        );
+        setStatusType("error");
       }
     });
   };
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <Button onClick={handleCreate} disabled={isCreating}>
-        {isCreating ? "Creating..." : "Create New Presentation"}
-      </Button>
+      <div className="flex flex-col items-center gap-2">
+        <Button onClick={handleCreate} disabled={isCreating} className="gap-2">
+          {isCreating && <Spinner />}
+          Create New Presentation
+        </Button>
+        {status && (
+          <p
+            className={cn(
+              "text-sm",
+              statusType === "error" ? "text-red-600" : "text-green-600"
+            )}
+          >
+            {status}
+          </p>
+        )}
+      </div>
     </main>
   );
 }

--- a/src/components/editor/PresentationEditor.test.tsx
+++ b/src/components/editor/PresentationEditor.test.tsx
@@ -21,10 +21,9 @@ describe("PresentationEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.location.hash = "#test-key";
-    window.alert = vi.fn(); // Mock window.alert
   });
 
-  it("should show an error alert if encryption fails on save", async () => {
+  it("should show an error message if encryption fails on save", async () => {
     const errorMessage = "Test encryption error";
     vi.mocked(crypto.importKey).mockResolvedValue({} as CryptoKey);
     vi.mocked(crypto.encrypt).mockRejectedValue(new Error(errorMessage));
@@ -39,11 +38,11 @@ describe("PresentationEditor", () => {
     // Click the save button
     fireEvent.click(screen.getByText("Save Changes"));
 
-    // Wait for the alert to be called
+    // Wait for the error message to appear
     await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith(
-        `Error saving: ${errorMessage}`
-      );
+      expect(
+        screen.getByText(`Error saving: ${errorMessage}`)
+      ).toBeInTheDocument();
     });
 
     // Ensure updatePresentation was not called
@@ -63,9 +62,9 @@ describe("PresentationEditor", () => {
     fireEvent.click(screen.getByText("Save Changes"));
 
     await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith(
-        "Cannot save. Decryption key or edit key is missing."
-      );
+      expect(
+        screen.getByText("Cannot save. Decryption key or edit key is missing.")
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/components/editor/ShareDialog.test.tsx
+++ b/src/components/editor/ShareDialog.test.tsx
@@ -1,6 +1,6 @@
 // src/components/editor/ShareDialog.test.tsx
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ShareDialog } from "./ShareDialog";
 
 const origin = window.location.origin;
@@ -12,7 +12,6 @@ describe("ShareDialog", () => {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
       writable: true,
     });
-    window.alert = vi.fn();
   });
 
   it("should not render when closed", () => {
@@ -27,7 +26,7 @@ describe("ShareDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("should copy edit link to clipboard", () => {
+  it("should copy edit link to clipboard", async () => {
     render(
       <ShareDialog isOpen onClose={() => {}} publicId="abc" editKey="ed1" />
     );
@@ -36,5 +35,8 @@ describe("ShareDialog", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       `${origin}/p/abc/e/ed1/h#testkey`
     );
+    await waitFor(() => {
+      expect(screen.getByText("Copied!")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/editor/ShareDialog.tsx
+++ b/src/components/editor/ShareDialog.tsx
@@ -15,6 +15,7 @@ interface ShareDialogProps {
 
 export function ShareDialog({ isOpen, onClose, publicId, editKey }: ShareDialogProps) {
   const [decryptionKey, setDecryptionKey] = useState("");
+  const [copied, setCopied] = useState<"edit" | "view" | null>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -30,8 +31,11 @@ export function ShareDialog({ isOpen, onClose, publicId, editKey }: ShareDialogP
   const viewUrl = `${baseUrl}/p/${publicId}/h#${decryptionKey}`;
   const editUrl = editKey ? `${baseUrl}/p/${publicId}/e/${editKey}/h#${decryptionKey}` : "";
 
-  const copyToClipboard = (text: string) => {
-    void navigator.clipboard.writeText(text).then(() => alert("Link copied to clipboard!"));
+  const copyToClipboard = (text: string, type: "edit" | "view") => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(type);
+      setTimeout(() => setCopied(null), 1500);
+    });
   };
 
   return (
@@ -43,18 +47,20 @@ export function ShareDialog({ isOpen, onClose, publicId, editKey }: ShareDialogP
           {editKey && (
             <div>
               <Label className="block text-sm font-medium text-gray-700">Your Private Edit Link (Keep this safe!)</Label>
-              <div className="flex space-x-2 mt-1">
+              <div className="flex items-center space-x-2 mt-1">
                 <Input type="text" readOnly value={editUrl} />
-                <Button onClick={() => copyToClipboard(editUrl)}>Copy</Button>
+                <Button onClick={() => copyToClipboard(editUrl, "edit")}>Copy</Button>
+                {copied === "edit" && <span className="text-sm text-green-600">Copied!</span>}
               </div>
             </div>
           )}
 
           <div>
             <Label className="block text-sm font-medium text-gray-700">Read-Only Link (For sharing)</Label>
-            <div className="flex space-x-2 mt-1">
+            <div className="flex items-center space-x-2 mt-1">
               <Input type="text" readOnly value={viewUrl} />
-              <Button onClick={() => copyToClipboard(viewUrl)}>Copy</Button>
+              <Button onClick={() => copyToClipboard(viewUrl, "view")}>Copy</Button>
+              {copied === "view" && <span className="text-sm text-green-600">Copied!</span>}
             </div>
           </div>
         </div>

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils";
+
+export function Spinner({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-block size-4 animate-spin rounded-full border-2 border-current border-r-transparent",
+        className
+      )}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- replace pop-up alerts with inline messages
- add a simple spinner component
- update editor toolbar layout so actions sit at the top
- show copy status inside ShareDialog
- adjust tests for new UI feedback

## Testing
- `node scripts/generate-themes.js`
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687d2109cf888333920f5bacdddc7ed4