### PR TITLE
Rename print view to presenter

### DIFF
--- a/src/app/present/p/[id]/h/page.tsx
+++ b/src/app/present/p/[id]/h/page.tsx
@@ -1,4 +1,4 @@
-// src/app/print/p/[id]/h/page.tsx
+// src/app/present/p/[id]/h/page.tsx
 import { getPresentation } from "@/app/actions";
 import { PrintWrapper } from "@/components/editor/PrintWrapper";
 import { notFound } from "next/navigation";

--- a/src/components/editor/PresentationEditor.tsx
+++ b/src/components/editor/PresentationEditor.tsx
@@ -96,7 +96,7 @@ export function PresentationEditor({
   const handlePrint = () => {
     const key = window.location.hash;
     // Open a dedicated print page, passing the key in the hash.
-    const printUrl = `/print/p/${presentation.publicId}/h${key}`;
+    const printUrl = `/present/p/${presentation.publicId}/h${key}`;
     window.open(printUrl, '_blank');
   };
 

--- a/src/components/editor/PresenterView.tsx
+++ b/src/components/editor/PresenterView.tsx
@@ -1,4 +1,4 @@
-// src/components/editor/PrintView2.tsx
+// src/components/editor/PresenterView.tsx
 "use client";
 
 import { useEffect, useRef } from "react";
@@ -13,7 +13,7 @@ import Notes from "reveal.js/plugin/notes/notes.esm.js";
 
 type Presentation = NonNullable<Awaited<ReturnType<typeof getPresentation>>>;
 
-interface PrintView2Props {
+interface PresenterViewProps {
   presentation: Presentation;
 }
 
@@ -22,7 +22,7 @@ interface PrintView2Props {
 // This is the correct pattern you provided.
 let deck: Reveal.Api | null = null;
 
-export function PrintView2({ presentation }: PrintView2Props) {
+export function PresenterView({ presentation }: PresenterViewProps) {
   const themeLinkRef = useRef<HTMLLinkElement | null>(null);
   const revealRef = useRef<HTMLDivElement | null>(null);
 
@@ -94,7 +94,7 @@ export function PrintView2({ presentation }: PrintView2Props) {
         try {
           deck.destroy();
         } catch (e) {
-          console.error("PrintView2: Error during Reveal.js destroy:", e);
+          console.error("PresenterView: Error during Reveal.js destroy:", e);
         }
         // Reset the singleton instance so it can be re-initialized if the page is ever revisited.
         deck = null;

--- a/src/components/editor/PrintWrapper.tsx
+++ b/src/components/editor/PrintWrapper.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from "react";
 import type { getPresentation } from "@/app/actions";
 import { decrypt, importKey } from "@/lib/crypto";
-import { PrintView2 } from "./PrintView2";
+import { PresenterView } from "./PresenterView";
 
 type Presentation = NonNullable<Awaited<ReturnType<typeof getPresentation>>>;
 
@@ -54,5 +54,5 @@ export function PrintWrapper({ presentation }: PrintWrapperProps) {
 
   const decryptedPresentation = { ...presentation, slides: decryptedSlides };
 
-  return <PrintView2 presentation={decryptedPresentation} />;
+  return <PresenterView presentation={decryptedPresentation} />;
 }


### PR DESCRIPTION
## Summary
- rename PrintView2 component to PresenterView
- update PrintWrapper to use PresenterView
- rename `/print` route to `/present`
- update PresentationEditor to open new URL

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687d277b1970833392255b5532139f9b