### PR TITLE
Disable editing when missing edit key

### DIFF
--- a/src/components/editor/PresentationEditor.test.tsx
+++ b/src/components/editor/PresentationEditor.test.tsx
@@ -67,4 +67,16 @@ describe("PresentationEditor", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("disables editing when no edit key is provided", () => {
+    render(<PresentationEditor presentation={mockPresentation} />);
+
+    const textarea = screen.getByDisplayValue("decrypted-content");
+    const addBtn = screen.getByText("Add New Slide");
+    const saveBtn = screen.getByText("Save Changes");
+
+    expect(textarea).toBeDisabled();
+    expect(addBtn).toBeDisabled();
+    expect(saveBtn).toBeDisabled();
+  });
 });

--- a/src/components/editor/PresentationEditor.tsx
+++ b/src/components/editor/PresentationEditor.tsx
@@ -142,6 +142,7 @@ export function PresentationEditor({
           content={slide.content}
           onContentChange={(newContent) => handleSlideChange(index, newContent)}
           theme={theme}
+          editable={hasEditAccess}
         />
       ))}
       <ShareDialog

--- a/src/components/editor/SlideEditor.test.tsx
+++ b/src/components/editor/SlideEditor.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SlideEditor } from "./SlideEditor";
+
+// Mock RevealPreview to avoid loading reveal.js in tests
+vi.mock("./RevealPreview", () => ({
+  RevealPreview: () => <div data-testid="reveal-preview" />,
+}));
+
+describe("SlideEditor", () => {
+  it("allows editing by default", () => {
+    const onChange = vi.fn();
+    render(<SlideEditor content="test" onContentChange={onChange} theme="black.css" />);
+    const textarea = screen.getByDisplayValue("test");
+    expect(textarea).not.toBeDisabled();
+    fireEvent.change(textarea, { target: { value: "updated" } });
+    expect(onChange).toHaveBeenCalledWith("updated");
+  });
+
+  it("disables textarea and ignores changes when editable is false", () => {
+    const onChange = vi.fn();
+    render(
+      <SlideEditor
+        content="test"
+        onContentChange={onChange}
+        theme="black.css"
+        editable={false}
+      />,
+    );
+    const textarea = screen.getByDisplayValue("test");
+    expect(textarea).toBeDisabled();
+    fireEvent.change(textarea, { target: { value: "new" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/SlideEditor.tsx
+++ b/src/components/editor/SlideEditor.tsx
@@ -12,9 +12,13 @@ interface SlideEditorProps {
   content: string;
   onContentChange: (newContent: string) => void;
   theme: string;
+  /**
+   * When false, the textarea should be read-only and changes ignored.
+   */
+  editable?: boolean;
 }
 
-export function SlideEditor({ content, onContentChange, theme }: SlideEditorProps) {
+export function SlideEditor({ content, onContentChange, theme, editable = true }: SlideEditorProps) {
   return (
     <div className="border rounded-lg p-4 space-y-4">
       <ResizablePanelGroup
@@ -26,8 +30,10 @@ export function SlideEditor({ content, onContentChange, theme }: SlideEditorProp
           <div className="p-4 h-full">
             <Textarea
               value={content}
-              onChange={(e) => onContentChange(e.target.value)}
+              onChange={editable ? (e) => onContentChange(e.target.value) : undefined}
               className="w-full h-full resize-none"
+              readOnly={!editable}
+              disabled={!editable}
             />
           </div>
         </ResizablePanel>


### PR DESCRIPTION
## Summary
- add `editable` prop to `SlideEditor` and disable textarea when edit key is absent
- pass edit key check from `PresentationEditor`
- add tests verifying editing is disabled with no edit key

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687d341c144883338268a09d4a4a6d48